### PR TITLE
エラーを運営用と競技者用にいい感じに分ける

### DIFF
--- a/bench/session/webapp.go
+++ b/bench/session/webapp.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/isucon/isucon9-qualify/bench/fails"
 	"github.com/tuotoo/qrcode"
 	"golang.org/x/xerrors"
 )
@@ -60,27 +61,27 @@ func (s *Session) Login(accountName, password string) (*AppUser, error) {
 	})
 	req, err := s.newPostRequest(ShareTargetURLs.AppURL, "/login", "application/json", bytes.NewBuffer(b))
 	if err != nil {
-		return nil, err
+		return nil, fails.NewError(err, "/login: リクエストに失敗しました")
 	}
 
 	res, err := s.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, fails.NewError(err, "/login: リクエストに失敗しました")
 	}
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
 		b, err := ioutil.ReadAll(res.Body)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to read res.Body and the status code of the response from api was not 200: %w", err)
+			return nil, fails.NewError(xerrors.Errorf("failed to read res.Body and the status code of the response from api was not 200: %w", err), "/login: レスポンスのステータスコードが200以外でかつbodyの読み込みに失敗しました")
 		}
-		return nil, fmt.Errorf("status code: %d; body: %s", res.StatusCode, b)
+		return nil, fails.NewError(fmt.Errorf("status code: %d; body: %s", res.StatusCode, b), "/login: レスポンスのステータスコードが200ではありません")
 	}
 
 	u := &AppUser{}
 	err = json.NewDecoder(res.Body).Decode(u)
 	if err != nil {
-		return nil, err
+		return nil, fails.NewError(err, "/login: JSONデコードに失敗しました")
 	}
 
 	return u, nil
@@ -89,31 +90,31 @@ func (s *Session) Login(accountName, password string) (*AppUser, error) {
 func (s *Session) SetSettings() error {
 	req, err := s.newGetRequest(ShareTargetURLs.AppURL, "/settings")
 	if err != nil {
-		return err
+		return fails.NewError(err, "/settings: リクエストに失敗しました")
 	}
 
 	res, err := s.Do(req)
 	if err != nil {
-		return err
+		return fails.NewError(err, "/settings: リクエストに失敗しました")
 	}
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
 		b, err := ioutil.ReadAll(res.Body)
 		if err != nil {
-			return xerrors.Errorf("failed to read res.Body and the status code of the response from api was not 200: %w", err)
+			return fails.NewError(xerrors.Errorf("failed to read res.Body and the status code of the response from api was not 200: %w", err), "/settings: レスポンスのステータスコードが200以外でかつbodyの読み込みに失敗しました")
 		}
-		return fmt.Errorf("status code: %d; body: %s", res.StatusCode, b)
+		return fails.NewError(fmt.Errorf("status code: %d; body: %s", res.StatusCode, b), "/settings: レスポンスのステータスコードが200ではありません")
 	}
 
 	rs := &resSetting{}
 	err = json.NewDecoder(res.Body).Decode(rs)
 	if err != nil {
-		return err
+		return fails.NewError(err, "/settings: JSONデコードに失敗しました")
 	}
 
 	if rs.CSRFToken == "" {
-		return fmt.Errorf("csrf token is empty")
+		return fails.NewError(fmt.Errorf("csrf token is empty"), "/settings: csrf tokenが空でした")
 	}
 
 	s.csrfToken = rs.CSRFToken
@@ -129,27 +130,27 @@ func (s *Session) Sell(name string, price int, description string) (int64, error
 	})
 	req, err := s.newPostRequest(ShareTargetURLs.AppURL, "/sell", "application/json", bytes.NewBuffer(b))
 	if err != nil {
-		return 0, err
+		return 0, fails.NewError(err, "/sell: リクエストに失敗しました")
 	}
 
 	res, err := s.Do(req)
 	if err != nil {
-		return 0, err
+		return 0, fails.NewError(err, "/sell: リクエストに失敗しました")
 	}
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
 		b, err := ioutil.ReadAll(res.Body)
 		if err != nil {
-			return 0, xerrors.Errorf("failed to read res.Body and the status code of the response from api was not 200: %w", err)
+			return 0, fails.NewError(xerrors.Errorf("failed to read res.Body and the status code of the response from api was not 200: %w", err), "/sell: レスポンスのステータスコードが200以外でかつbodyの読み込みに失敗しました")
 		}
-		return 0, fmt.Errorf("status code: %d; body: %s", res.StatusCode, b)
+		return 0, fails.NewError(fmt.Errorf("status code: %d; body: %s", res.StatusCode, b), "/sell: レスポンスのステータスコードが200ではありません")
 	}
 
 	rs := &resSell{}
 	err = json.NewDecoder(res.Body).Decode(rs)
 	if err != nil {
-		return 0, err
+		return 0, fails.NewError(err, "/sell: JSONデコードに失敗しました")
 	}
 
 	return rs.ID, nil
@@ -163,26 +164,26 @@ func (s *Session) Buy(itemID int64, token string) error {
 	})
 	req, err := s.newPostRequest(ShareTargetURLs.AppURL, "/buy", "application/json", bytes.NewBuffer(b))
 	if err != nil {
-		return err
+		return fails.NewError(err, "/buy: リクエストに失敗しました")
 	}
 
 	res, err := s.Do(req)
 	if err != nil {
-		return err
+		return fails.NewError(err, "/buy: リクエストに失敗しました")
 	}
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
 		b, err := ioutil.ReadAll(res.Body)
 		if err != nil {
-			return xerrors.Errorf("failed to read res.Body and the status code of the response from api was not 200: %w", err)
+			return fails.NewError(xerrors.Errorf("failed to read res.Body and the status code of the response from api was not 200: %w", err), "/buy: レスポンスのステータスコードが200以外でかつbodyの読み込みに失敗しました")
 		}
-		return fmt.Errorf("status code: %d; body: %s", res.StatusCode, b)
+		return fails.NewError(fmt.Errorf("status code: %d; body: %s", res.StatusCode, b), "/buy: レスポンスのステータスコードが200ではありません")
 	}
 
 	_, err = ioutil.ReadAll(res.Body)
 	if err != nil {
-		return err
+		return fails.NewError(err, "/buy: bodyの読み込みに失敗しました")
 	}
 
 	return nil
@@ -195,27 +196,27 @@ func (s *Session) Ship(itemID int64) (aurl string, err error) {
 	})
 	req, err := s.newPostRequest(ShareTargetURLs.AppURL, "/ship", "application/json", bytes.NewBuffer(b))
 	if err != nil {
-		return "", err
+		return "", fails.NewError(err, "/ship: リクエストに失敗しました")
 	}
 
 	res, err := s.Do(req)
 	if err != nil {
-		return "", err
+		return "", fails.NewError(err, "/ship: リクエストに失敗しました")
 	}
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
 		b, err := ioutil.ReadAll(res.Body)
 		if err != nil {
-			return "", xerrors.Errorf("failed to read res.Body and the status code of the response from api was not 200: %w", err)
+			return "", fails.NewError(xerrors.Errorf("failed to read res.Body and the status code of the response from api was not 200: %w", err), "/ship: レスポンスのステータスコードが200以外でかつbodyの読み込みに失敗しました")
 		}
-		return "", fmt.Errorf("status code: %d; body: %s", res.StatusCode, b)
+		return "", fails.NewError(fmt.Errorf("status code: %d; body: %s", res.StatusCode, b), "/ship: レスポンスのステータスコードが200ではありません")
 	}
 
 	rs := &resShip{}
 	err = json.NewDecoder(res.Body).Decode(rs)
 	if err != nil {
-		return "", err
+		return "", fails.NewError(err, "/ship: JSONデコードに失敗しました")
 	}
 
 	return rs.URL, nil
@@ -228,26 +229,26 @@ func (s *Session) ShipDone(itemID int64) error {
 	})
 	req, err := s.newPostRequest(ShareTargetURLs.AppURL, "/ship_done", "application/json", bytes.NewBuffer(b))
 	if err != nil {
-		return err
+		return fails.NewError(err, "/ship_done: リクエストに失敗しました")
 	}
 
 	res, err := s.Do(req)
 	if err != nil {
-		return err
+		return fails.NewError(err, "/ship_done: リクエストに失敗しました")
 	}
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
 		b, err := ioutil.ReadAll(res.Body)
 		if err != nil {
-			return xerrors.Errorf("failed to read res.Body and the status code of the response from api was not 200: %w", err)
+			return fails.NewError(xerrors.Errorf("failed to read res.Body and the status code of the response from api was not 200: %w", err), "/ship_done: レスポンスのステータスコードが200以外でかつbodyの読み込みに失敗しました")
 		}
-		return fmt.Errorf("status code: %d; body: %s", res.StatusCode, b)
+		return fails.NewError(fmt.Errorf("status code: %d; body: %s", res.StatusCode, b), "/ship_done: レスポンスのステータスコードが200ではありません")
 	}
 
 	_, err = ioutil.ReadAll(res.Body)
 	if err != nil {
-		return err
+		return fails.NewError(err, "/ship_done: bodyの読み込みに失敗しました")
 	}
 
 	return nil
@@ -260,26 +261,26 @@ func (s *Session) Complete(itemID int64) error {
 	})
 	req, err := s.newPostRequest(ShareTargetURLs.AppURL, "/complete", "application/json", bytes.NewBuffer(b))
 	if err != nil {
-		return err
+		return fails.NewError(err, "/complete: リクエストに失敗しました")
 	}
 
 	res, err := s.Do(req)
 	if err != nil {
-		return err
+		return fails.NewError(err, "/complete: リクエストに失敗しました")
 	}
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
 		b, err := ioutil.ReadAll(res.Body)
 		if err != nil {
-			return xerrors.Errorf("failed to read res.Body and the status code of the response from api was not 200: %w", err)
+			return fails.NewError(xerrors.Errorf("failed to read res.Body and the status code of the response from api was not 200: %w", err), "/complete: レスポンスのステータスコードが200以外でかつbodyの読み込みに失敗しました")
 		}
-		return fmt.Errorf("status code: %d; body: %s", res.StatusCode, b)
+		return fails.NewError(fmt.Errorf("status code: %d; body: %s", res.StatusCode, b), "/complete: レスポンスのステータスコードが200ではありません")
 	}
 
 	_, err = ioutil.ReadAll(res.Body)
 	if err != nil {
-		return err
+		return fails.NewError(err, "/complete: bodyの読み込みに失敗しました")
 	}
 
 	return nil
@@ -287,55 +288,55 @@ func (s *Session) Complete(itemID int64) error {
 
 func (s *Session) DecodeQRURL(aurl string) (*url.URL, error) {
 	if len(aurl) == 0 {
-		return nil, fmt.Errorf("urlが空です")
+		return nil, fails.NewError(nil, "URLが空です")
 	}
 
 	parsedURL, err := url.ParseRequestURI(aurl)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse url: %s: %w", aurl, err)
+		return nil, fails.NewError(err, "QRコードの画像URLがURLとして解釈できません")
 	}
 
 	if parsedURL.Host != ShareTargetURLs.AppURL.Host {
-		return nil, fmt.Errorf("画像はアプリケーションのドメインで配信する必要があります")
+		return nil, fails.NewError(nil, "画像はアプリケーションのドメインで配信する必要があります")
 	}
 
 	req, err := s.newGetRequest(parsedURL, "")
 	if err != nil {
-		return nil, err
+		return nil, fails.NewError(err, "リクエストに失敗しました")
 	}
 
 	res, err := s.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, fails.NewError(err, "リクエストに失敗しました")
 	}
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
 		b, err := ioutil.ReadAll(res.Body)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to read res.Body and the status code of the response from api was not 200: %w", err)
+			return nil, fails.NewError(xerrors.Errorf("failed to read res.Body and the status code of the response from api was not 200: %w", err), "QRコードの画像へのリクエストがステータスコード200以外でbodyの読み込みにも失敗しました")
 		}
-		return nil, fmt.Errorf("status code: %d; body: %s", res.StatusCode, b)
+		return nil, fails.NewError(fmt.Errorf("status code: %d; body: %s", res.StatusCode, b), "QRコードの画像へのリクエストがステータスコード200以外でした")
 	}
 
 	qrmatrix, err := qrcode.Decode(res.Body)
 	if err != nil {
-		return nil, err
+		return nil, fails.NewError(err, "QRコードがデコードできませんでした")
 	}
 
 	surl := qrmatrix.Content
 
 	if len(surl) == 0 {
-		return nil, fmt.Errorf("QRコードの中身が空です")
+		return nil, fails.NewError(nil, "QRコードの中身が空です")
 	}
 
 	sparsedURL, err := url.ParseRequestURI(surl)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse url: %s: %w", surl, err)
+		return nil, fails.NewError(err, "QRコードの中身がURLではありません")
 	}
 
 	if sparsedURL.Host != ShareTargetURLs.ShipmentURL.Host {
-		return nil, fmt.Errorf("shipment serviceのドメイン以外のURLがQRコードに表示されています")
+		return nil, fails.NewError(nil, "shipment serviceのドメイン以外のURLがQRコードに表示されています")
 	}
 
 	return sparsedURL, nil

--- a/cmd/bench/main.go
+++ b/cmd/bench/main.go
@@ -1,11 +1,16 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
 	"log"
 	"net"
 	"net/http"
+	"os"
+	"sync"
 	"time"
 
+	"github.com/isucon/isucon9-qualify/bench/fails"
 	"github.com/isucon/isucon9-qualify/bench/server"
 	"github.com/isucon/isucon9-qualify/bench/session"
 	"github.com/k0kubun/pp"
@@ -38,7 +43,32 @@ func main() {
 		log.Println(serverShipment.Serve(liShipment))
 	}()
 
-	run()
+	fmt.Fprintf(os.Stderr, "=== initialize ===\n")
+	initialize()
+	fmt.Fprintf(os.Stderr, "=== verify ===\n")
+
+	cerr := verify()
+	criticalMsgs := cerr.GetMsgs()
+	if len(criticalMsgs) > 0 {
+		fmt.Fprintf(os.Stderr, "cause error!\n")
+
+		output := Output{
+			Pass:     false,
+			Score:    0,
+			Messages: criticalMsgs,
+		}
+		json.NewEncoder(os.Stdout).Encode(output)
+
+		return
+	}
+
+	fmt.Fprintf(os.Stderr, "=== validation ===\n")
+}
+
+type Output struct {
+	Pass     bool     `json:"pass"`
+	Score    int64    `json:"score"`
+	Messages []string `json:"messages"`
 }
 
 type Server struct {
@@ -49,91 +79,112 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.mux.ServeHTTP(w, r)
 }
 
-func run() int {
+func initialize() {
+}
+
+func scenarioSellAndBuy() error {
 	err := session.SetShareTargetURLs(
 		"http://localhost:8000",
 		"http://localhost:5555",
 		"http://localhost:7000",
 	)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	s1, err := session.NewSession()
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	s2, err := session.NewSession()
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	seller, err := s1.Login("aaa", "aaa")
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	pp.Println(seller)
 	err = s1.SetSettings()
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	buyer, err := s2.Login("bbb", "bbb")
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	pp.Println(buyer)
 	err = s2.SetSettings()
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	targetItemID, err := s1.Sell("abcd", 100, "description description")
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	token, err := s2.PaymentCard("AAAAAAAA", "11")
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	err = s2.Buy(targetItemID, token)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	aurl, err := s1.Ship(targetItemID)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
-	pp.Println(aurl)
 
 	s3, err := session.NewSession()
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	surl, err := s3.DecodeQRURL(aurl)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	pp.Println(surl.String())
 
 	err = s3.ShipmentAccept(surl)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	err = s1.ShipDone(targetItemID)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	time.Sleep(6 * time.Second)
 
 	err = s2.Complete(targetItemID)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
-	return 0
+	return nil
+}
+
+func verify() *fails.Critical {
+	var wg sync.WaitGroup
+
+	critical := fails.NewCritical()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := scenarioSellAndBuy()
+		if err != nil {
+			critical.Add(err)
+		}
+	}()
+
+	wg.Wait()
+
+	return critical
 }


### PR DESCRIPTION
うまくいくかどうかは分からないけど

* 各処理はエラーを返すときにエラーと競技者に見せるメッセージを持つ独自のエラー型を返す
  * 関数の返値はあくまでも`error`なのでキャストしてから取り出す。そうしないとエラーのnil判定ができなくなる
  * refs: https://golang.org/doc/faq#nil_error
* エラーができたときは標準エラー出力に出す（運営のみが見る）
* criticalかどうかはエラーとは別に扱う
  * initialize verifyはcritical扱いになりうる
  * validationはcritical扱いなし

という方針でやってみたい

refs: https://github.com/catatsuy/isucon9-qualify/issues/1


