### PR TITLE
新着商品/カテゴリ商品のAPI修正

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -394,8 +394,9 @@ func getNewItems(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
 	itemIDStr := query.Get("item_id")
 	var itemID int64
+	var err error
 	if itemIDStr != "" {
-		itemID, err := strconv.ParseInt(itemIDStr, 10, 64)
+		itemID, err = strconv.ParseInt(itemIDStr, 10, 64)
 		if err != nil || itemID <= 0 {
 			outputErrorMsg(w, http.StatusBadRequest, "item_id param error")
 			return
@@ -405,7 +406,7 @@ func getNewItems(w http.ResponseWriter, r *http.Request) {
 	createdAtStr := query.Get("created_at")
 	var createdAt int64
 	if createdAtStr != "" {
-		createdAt, err := strconv.ParseInt(createdAtStr, 10, 64)
+		createdAt, err = strconv.ParseInt(createdAtStr, 10, 64)
 		if err != nil || createdAt <= 0 {
 			outputErrorMsg(w, http.StatusBadRequest, "created_at param error")
 			return
@@ -509,7 +510,7 @@ func getNewCategoryItems(w http.ResponseWriter, r *http.Request) {
 	itemIDStr := query.Get("item_id")
 	var itemID int64
 	if itemIDStr != "" {
-		itemID, _ := strconv.ParseInt(itemIDStr, 10, 64)
+		itemID, err = strconv.ParseInt(itemIDStr, 10, 64)
 		if err != nil || itemID <= 0 {
 			outputErrorMsg(w, http.StatusBadRequest, "item_id param error")
 			return
@@ -519,7 +520,7 @@ func getNewCategoryItems(w http.ResponseWriter, r *http.Request) {
 	createdAtStr := query.Get("created_at")
 	var createdAt int64
 	if createdAtStr != "" {
-		createdAt, err := strconv.ParseInt(createdAtStr, 10, 64)
+		createdAt, err = strconv.ParseInt(createdAtStr, 10, 64)
 		if err != nil || createdAt <= 0 {
 			outputErrorMsg(w, http.StatusBadRequest, "created_at param error")
 			return


### PR DESCRIPTION
- `item_id`, `created_at`を指定しても`0`としてSQLが実行されているのを修正