### PR TITLE
DNSを通さないでもベンチマークを通せるように

### DIFF
--- a/cmd/bench/main.go
+++ b/cmd/bench/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"log"
 	"math/rand"
 	"os"
@@ -18,6 +19,13 @@ type Output struct {
 	Messages []string `json:"messages"`
 }
 
+type Config struct {
+	// PaymentPort    int
+	// ShipmentPort   int
+	TargetURLStr string
+	TargetHost   string
+}
+
 func init() {
 	rand.Seed(time.Now().UnixNano())
 
@@ -25,13 +33,27 @@ func init() {
 }
 
 func main() {
-	err := server.RunServer(5555, 7000)
+	flags := flag.NewFlagSet("isucon9q", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+
+	conf := Config{}
+
+	flags.StringVar(&conf.TargetURLStr, "target-url", "http://127.0.0.1:8000", "target url")
+	flags.StringVar(&conf.TargetHost, "target-host", "isucon9.catatsuy.org", "target host")
+
+	err := flags.Parse(os.Args[1:])
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = server.RunServer(5555, 7000)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	err = session.SetShareTargetURLs(
-		"http://localhost:8000",
+		conf.TargetURLStr,
+		conf.TargetHost,
 		"http://localhost:5555",
 		"http://localhost:7000",
 	)


### PR DESCRIPTION
現状は手抜き実装だが、ほぼこのままいけるかもしれない
これで競技者は全員同じ証明書でいい感じにベンチマークできる