### PR TITLE
nodejs's mysql driver does not support mysql8's default auth plugin

### DIFF
--- a/webapp/sql/00_create_database.sql
+++ b/webapp/sql/00_create_database.sql
@@ -2,9 +2,9 @@ DROP DATABASE IF EXISTS `isucari`;
 CREATE DATABASE `isucari`;
 
 DROP USER IF EXISTS 'isucari'@'localhost';
-CREATE USER 'isucari'@'localhost' IDENTIFIED BY 'isucari';
+CREATE USER 'isucari'@'localhost' IDENTIFIED WITH mysql_native_password BY 'isucari';
 GRANT ALL PRIVILEGES ON `isucari`.* TO 'isucari'@'localhost';
 
 DROP USER IF EXISTS 'isucari'@'%';
-CREATE USER 'isucari'@'%' IDENTIFIED BY 'isucari';
+CREATE USER 'isucari'@'%' IDENTIFIED WITH mysql_native_password BY 'isucari';
 GRANT ALL PRIVILEGES ON `isucari`.* TO 'isucari'@'%';


### PR DESCRIPTION
## 提案

 nodejsのmysql driverの都合でmysqlのisucari userの認証方式をmysql 5.7以前のものにしたいです。他の言語でも問題がないのであれば。他の言語で問題があるのなら別の方法を探します（最悪READMEに解決方法を書いておく、とかでもいいっちゃいいですが、ハマりどころが少ないにこしたことはないので）。

なお、この方法だと問題なく接続できることは確認しております。

## 理由

2019年8月現在、nodejsでメジャーなmysql driverであるところのmysqlとmysql2がmysql8でデフォルトになった新しい認証方式に対応してません（たとえばmysql moduleの場合はPRが1年以上WIPのままで、進捗が無いわけではないもののいつマージされてリリースされるか不明）。mysql8を使うならいろいろ工夫が必要なんですが、userをつくるときにlegacy方式の認証をするのが一番手っ取り早そうでした。

cf. https://stackoverflow.com/questions/50373427/node-js-cant-authenticate-to-mysql-8-0

mysql2 moduleのissue: https://github.com/sidorares/node-mysql2/issues/991
mysql moduleのPR: https://github.com/mysqljs/mysql/pull/2233

---

去年はどうだったかなあというと、MariaDBっぽい…（そうだった気はする）。最初mysql8をいれて認証できなくてトラブってよくみたらMariaDBで、MariaDBだと（去年の時点では）問題なかった、というような気がします。

https://github.com/isucon/isucon8-qualify/blob/935fc8f185b66f8c58f7a77a4a5836f70a906102/provisioning/roles/install_mariadb/tasks/main.yml