### PR TITLE
Add env LANG="C.UTF-8"

### DIFF
--- a/webapp/sql/init.sh
+++ b/webapp/sql/init.sh
@@ -4,6 +4,7 @@ set -o pipefail
 
 CURRENT_DIR=$(cd $(dirname $0);pwd)
 export MYSQL_PWD="isucari"
+export LANG="C.UTF-8"
 cd $CURRENT_DIR
 
 cat 01_schema.sql 02_categories.sql initial.sql | mysql --defaults-file=/dev/null -u isucari isucari


### PR DESCRIPTION
webapp から 実行される init.sh に 環境変数 `LANG="C.UTF-8"` を追加。UTF8系のLANGしてされていないと ASCII に fallback され、initialize で日本語データの投入に失敗するため。