### PR TITLE
[bench] time.Tickのリーク

### DIFF
--- a/bench/scenario/campaign.go
+++ b/bench/scenario/campaign.go
@@ -112,7 +112,8 @@ func Campaign(ctx context.Context, critical *fails.Critical) {
 		defer wg.Done()
 		<-time.After(20 * time.Second)
 
-		tick := time.Tick(10 * time.Second)
+		ticker := time.NewTicker(10 * time.Second)
+		defer ticker.Stop()
 
 	L:
 		for i := 1; i < ExecutionSeconds/10-2; i++ {
@@ -125,7 +126,7 @@ func Campaign(ctx context.Context, critical *fails.Critical) {
 			priceStoreCache.Set(100 + i*50)
 
 			select {
-			case <-tick:
+			case <-ticker.C:
 			case <-ctx.Done():
 				break L
 			}


### PR DESCRIPTION
using time.Tick leaks the underlying ticker, consider using it only in
endless functions, tests and the main package, and use time.NewTicker
here (SA1015)