### PR TITLE
[bench] use ForceAttemptHTTP2 for http2

### DIFF
--- a/bench/session/new.go
+++ b/bench/session/new.go
@@ -1,0 +1,51 @@
+// +build !go1.13
+
+package session
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/http/cookiejar"
+	"time"
+)
+
+func NewSession() (*Session, error) {
+	jar, _ := cookiejar.New(&cookiejar.Options{})
+
+	s := &Session{
+		httpClient: &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					// HTTPの時は無視されるだけ
+					ServerName: ShareTargetURLs.TargetHost,
+				},
+			},
+			Jar:     jar,
+			Timeout: time.Duration(DefaultAPITimeout) * time.Second,
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return fmt.Errorf("redirect attempted")
+			},
+		},
+	}
+
+	return s, nil
+}
+
+func NewSessionForInialize() (*Session, error) {
+	s := &Session{
+		httpClient: &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					// HTTPの時は無視されるだけ
+					ServerName: ShareTargetURLs.TargetHost,
+				},
+			},
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return fmt.Errorf("redirect attempted")
+			},
+		},
+	}
+
+	return s, nil
+}

--- a/bench/session/new113.go
+++ b/bench/session/new113.go
@@ -1,0 +1,55 @@
+// +build go1.13
+
+package session
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/http/cookiejar"
+	"time"
+)
+
+func NewSession() (*Session, error) {
+	jar, _ := cookiejar.New(&cookiejar.Options{})
+
+	s := &Session{
+		httpClient: &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					// HTTPの時は無視されるだけ
+					ServerName: ShareTargetURLs.TargetHost,
+				},
+				// TLSClientConfigを上書きしてもHTTP/2を使えるように
+				ForceAttemptHTTP2: true,
+			},
+			Jar:     jar,
+			Timeout: time.Duration(DefaultAPITimeout) * time.Second,
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return fmt.Errorf("redirect attempted")
+			},
+		},
+	}
+
+	return s, nil
+}
+
+func NewSessionForInialize() (*Session, error) {
+	s := &Session{
+		httpClient: &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					// HTTPの時は無視されるだけ
+					ServerName: ShareTargetURLs.TargetHost,
+				},
+				// TLSClientConfigを上書きしてもHTTP/2を使えるように
+				ForceAttemptHTTP2: true,
+			},
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return fmt.Errorf("redirect attempted")
+			},
+		},
+	}
+
+	return s, nil
+}

--- a/bench/session/session.go
+++ b/bench/session/session.go
@@ -1,15 +1,12 @@
 package session
 
 import (
-	"crypto/tls"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
-	"net/http/cookiejar"
 	"net/url"
-	"time"
 
 	"github.com/isucon/isucon9-qualify/bench/fails"
 	"github.com/morikuni/failure"
@@ -98,46 +95,6 @@ func urlParse(ref string) (*url.URL, error) {
 		Scheme: u.Scheme,
 		Host:   u.Host,
 	}, nil
-}
-
-func NewSession() (*Session, error) {
-	jar, _ := cookiejar.New(&cookiejar.Options{})
-
-	s := &Session{
-		httpClient: &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{
-					// HTTPの時は無視されるだけ
-					ServerName: ShareTargetURLs.TargetHost,
-				},
-			},
-			Jar:     jar,
-			Timeout: time.Duration(DefaultAPITimeout) * time.Second,
-			CheckRedirect: func(req *http.Request, via []*http.Request) error {
-				return fmt.Errorf("redirect attempted")
-			},
-		},
-	}
-
-	return s, nil
-}
-
-func NewSessionForInialize() (*Session, error) {
-	s := &Session{
-		httpClient: &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{
-					// HTTPの時は無視されるだけ
-					ServerName: ShareTargetURLs.TargetHost,
-				},
-			},
-			CheckRedirect: func(req *http.Request, via []*http.Request) error {
-				return fmt.Errorf("redirect attempted")
-			},
-		},
-	}
-
-	return s, nil
 }
 
 func (s *Session) newGetRequest(u url.URL, spath string) (*http.Request, error) {


### PR DESCRIPTION
Go1.13しか使えないのでbuild constraintで分けておく

```
wget https://dl.google.com/go/go1.13rc2.darwin-amd64.tar.gz
wget https://dl.google.com/go/go1.13rc2.linux-amd64.tar.gz
```

refs: #138