### PR TITLE
fixed new-item check

### DIFF
--- a/bench/asset/asset.go
+++ b/bench/asset/asset.go
@@ -444,6 +444,7 @@ func SetItem(sellerID int64, itemID int64, name string, price int, description s
 
 	userItems[sellerID] = append(userItems[sellerID], itemID)
 
+	// imageName は更新できない
 	key := fmt.Sprintf("%d_%d", sellerID, itemID)
 	items[key] = AppItem{
 		ID:          itemID,

--- a/bench/scenario/verify.go
+++ b/bench/scenario/verify.go
@@ -754,7 +754,8 @@ func verifyGetItem(ctx context.Context, s *session.Session, targetItemID int64) 
 	if !(item.Description == aItem.Description) {
 		return failure.New(fails.ErrApplication, failure.Messagef("/items/%d.jsonの商品説明が間違っています", targetItemID))
 	}
-	if !(item.ImageURL == getImageURL(aItem.ImageName)) {
+	// 新規出品分はここで画像のチェックができない
+	if aItem.ImageName != "" && item.ImageURL != getImageURL(aItem.ImageName) {
 		return failure.New(fails.ErrApplication, failure.Messagef("/items/%d.jsonの商品画像URLが間違っています", targetItemID))
 	}
 


### PR DESCRIPTION
`"/items/50001.jsonの商品画像URLが間違っています"`
これを防ぐ。
新規出品分は、imageNameを取得することができず、エラーになる