### PR TITLE
BuildKitを使わないようにする

### DIFF
--- a/initial-data/Makefile
+++ b/initial-data/Makefile
@@ -1,7 +1,7 @@
 all: build install-sql
 
 build: Dockerfile *.tsv *.pl
-	docker build -t isucon9-qualify/initial-data .
+	DOCKER_BUILDKIT=0 docker build -t isucon9-qualify/initial-data .
 	docker run -v $(shell pwd)/result:/opt/initial-data/result -v $(shell pwd)/pwcache:/opt/initial-data/pwcache isucon9-qualify/initial-data
 
 install-sql:


### PR DESCRIPTION
### 問題点
BuildKitを有効にして`make`すると落ちる
```
$ cd initial-data
$ make
```
```
 => [internal] load build context                                        0.2s
 => => transferring context: 1.02MB                                      0.1s
 => [2/8] RUN mkdir -p /opt/initial-data/result                          0.9s
 => ERROR [3/8] RUN cpanm -n Crypt::Eksblowfish::Bcrypt Crypt::OpenSSL:  0.5s
------
 > [3/8] RUN cpanm -n Crypt::Eksblowfish::Bcrypt Crypt::OpenSSL::Random Digest::SHA JSON JSON::Types;:
#6 0.434 /bin/sh: 1: cpanm: not found
------
failed to solve with frontend dockerfile.v0: failed to build LLB: executor failed running [/bin/sh -c cpanm -n Crypt::Eksblowfish::Bcrypt Crypt::OpenSSL::Random Digest::SHA JSON JSON::Types;]: runc did not terminate sucessfully
make: *** [build] Error 1
```

### 改善策
BuildKitを明示的に無効化する