### PR TITLE
Add purl download and move files for purl installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,18 @@ jobs:
             echo "ruby_changes_detected=true" >> $GITHUB_OUTPUT
           fi
 
+      - name: Download purl
+        run: |
+          curl -sL https://github.com/catatsuy/purl/releases/latest/download/purl-linux-amd64.tar.gz | tar xz -C /tmp
+
+      - name: Move files to /usr/local/bin for purl
+        run: |
+          sudo mv /tmp/purl /usr/local/bin/
+
       - name: Update compose.yml if changes are detected
         if: steps.check-changes.outputs.ruby_changes_detected == 'true'
         run: |
-          perl -i -pe 's@dockerfile: go/@dockerfile: ruby/@g' ./webapp/compose.yml
+          purl -overwrite -replace '@dockerfile: go/@dockerfile: ruby/@' ./webapp/compose.yml
 
       - name: Start the server
         run: |


### PR DESCRIPTION
This pull request includes changes to the Continuous Integration (CI) workflow configuration in `.github/workflows/ci.yml`. The changes involve switching from using Perl to Purl for modifying the `compose.yml` file, and adding steps to download and install Purl. 

Here are the key changes:

* In `.github/workflows/ci.yml`, added a new step to download Purl, a command-line tool used for string manipulation. This step downloads the latest Purl release from GitHub and extracts the downloaded tarball to the `/tmp` directory.
* Added another step to move the Purl binary from `/tmp` to `/usr/local/bin/`, making it available for use in the workflow.
* Modified the step that updates the `compose.yml` file. Previously, this step used Perl for string replacement in the file. Now, it uses Purl with the `-overwrite` and `-replace` options to perform the same task.