### PR TITLE
Add packageRules for docker nginx versioning in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,6 +35,17 @@
       ]
     }
   ],
+  "packageRules": [
+    {
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "nginx"
+      ],
+      "versioning": "regex:^(?<major>[0-9]+)\\.(?<minor>[0-9]*[02468])(?<patch>\\d*)$"
+    }
+  ],
   "postUpdateOptions": [
     "gomodTidy",
     "gomodUpdateImportPaths"


### PR DESCRIPTION
This pull request includes a change to the `renovate.json` file. The change introduces a new package rule for Docker data sources, specifically for the `nginx` package. This rule uses a regular expression for versioning, which appears to enforce a certain pattern for major, minor, and patch versions.