### PR TITLE
Add compose.yml files to CI workflow paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ on:
       - "Makefile"
       - "go.mod"
       - "go.sum"
+      - "compose.yml"
+      - "webapp/compose.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/ci.yml` file. The change expands the list of files that trigger the CI workflow, ensuring that any changes to `compose.yml` and `webapp/compose.yml` will also cause the workflow to run.