### PR TITLE
Add rack gem to Gemfile

### DIFF
--- a/webapp/ruby/Gemfile
+++ b/webapp/ruby/Gemfile
@@ -5,6 +5,7 @@ gem 'sinatra'
 gem 'mysql2'
 gem 'mysql2-cs-bind'
 gem 'bcrypt'
+gem 'rack'
 gem 'rackup'
 
 group :development do


### PR DESCRIPTION
This pull request includes a small addition to the `Gemfile` in the `webapp/ruby` directory. The change adds the `rack` gem to the list of dependencies for the Ruby web application.