### PR TITLE
Add mysql service dependency in compose.yml and update go Dockerfile

### DIFF
--- a/webapp/compose.yml
+++ b/webapp/compose.yml
@@ -15,6 +15,9 @@ services:
       context: .
       # rubyを使うならruby/Dockerfile
       dockerfile: go/Dockerfile
+    depends_on:
+      mysql:
+        condition: service_started
     environment:
       MYSQL_HOST: mysql
       MYSQL_PORT: 3306

--- a/webapp/go/Dockerfile
+++ b/webapp/go/Dockerfile
@@ -1,18 +1,22 @@
+#syntax=docker/dockerfile:1
+
 FROM golang:1.22-bookworm
 
-RUN apt-get update && apt-get install -y \
-  default-mysql-client \
-  && rm -rf /var/lib/apt/lists/*
+RUN \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  apt-get update -qq && apt-get install -y \
+  default-mysql-client
 
-RUN mkdir -p /home/webapp
 WORKDIR /home/webapp
 
 COPY init.sh /home/init.sh
 
 COPY go/go.mod /home/webapp/go.mod
 COPY go/go.sum /home/webapp/go.sum
-RUN go mod download
+RUN go mod download -x
 
 COPY go /home/webapp
 RUN go build -o app
-CMD ./app
+
+ENTRYPOINT [ "./app" ]


### PR DESCRIPTION
This pull request includes several changes to the `webapp` service configuration and Docker setup. The most important changes involve updating the Dockerfile for the Go application and modifying the `compose.yml` file to ensure proper service dependencies.

### Dockerfile updates:
* Added Dockerfile syntax directive at the top. (`webapp/go/Dockerfile`)
* Changed `RUN go mod download` to include the `-x` flag for more detailed output. (`webapp/go/Dockerfile`)
* Replaced `CMD ./app` with `ENTRYPOINT [ "./app" ]` to set the entry point for the container. (`webapp/go/Dockerfile`)

### Service configuration:
* Added `depends_on` section to ensure the MySQL service starts before the main service. (`webapp/compose.yml`)