### PR TITLE
Refactor Dockerfile to use multi-stage builds and add non-privileged user

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Run the benchmark
         continue-on-error: true
         run: |
-          docker run --add-host host.docker.internal:host-gateway -p 5678:5678 -p 7890:7890 -i isucari-benchmarker /opt/go/benchmarker -target-url http://host.docker.internal -data-dir /initial-data -static-dir /static -payment-url http://host.docker.internal:5678 -payment-port 5678 -shipment-url http://host.docker.internal:7890 -shipment-port 7890 || echo "BENCHMARK_FAILED=true" >> $GITHUB_ENV
+          docker container run --add-host host.docker.internal:host-gateway -p 5678:5678 -p 7890:7890 -i isucari-benchmarker /bin/benchmarker -target-url http://host.docker.internal -data-dir /initial-data -static-dir /static -payment-url http://host.docker.internal:5678 -payment-port 5678 -shipment-url http://host.docker.internal:7890 -shipment-port 7890 || echo "BENCHMARK_FAILED=true" >> $GITHUB_ENV
 
       - name: Show logs
         run: |

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ docker compose up
 docker build -t isucari-benchmarker -f bench/Dockerfile .
 
 # benchmarkerの実行（Linuxは --add-host host.docker.internal:host-gateway を追加）
-docker run -p 5678:5678 -p 7890:7890 -i isucari-benchmarker /opt/go/benchmarker -target-url http://host.docker.internal -data-dir /initial-data -static-dir /static -payment-url http://host.docker.internal:5678 -payment-port 5678 -shipment-url http://host.docker.internal:7890 -shipment-port 7890
+docker container run -p 5678:5678 -p 7890:7890 -i isucari-benchmarker /bin/benchmarker -target-url http://host.docker.internal -data-dir /initial-data -static-dir /static -payment-url http://host.docker.internal:5678 -payment-port 5678 -shipment-url http://host.docker.internal:7890 -shipment-port 7890
 ```
 
 ### external service

--- a/bench/Dockerfile
+++ b/bench/Dockerfile
@@ -1,18 +1,49 @@
-FROM golang:1.22
+# syntax=docker/dockerfile:1
 
-RUN mkdir -p /opt/go
-WORKDIR /opt/go
+FROM --platform=$BUILDPLATFORM golang:1.22 AS build
+WORKDIR /src
+
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+  --mount=type=bind,source=go.sum,target=go.sum \
+  --mount=type=bind,source=go.mod,target=go.mod \
+  go mod download -x
+
+COPY cmd/ /src/cmd
+COPY bench/ /src/bench
+
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+  --mount=type=bind,target=. \
+  CGO_ENABLED=0 go build -o /bin/benchmarker cmd/bench/main.go
+
+
+FROM alpine:latest AS final
+
+RUN --mount=type=cache,target=/var/cache/apk \
+  apk --update add \
+  ca-certificates \
+  tzdata \
+  && \
+  update-ca-certificates
+
+# Create a non-privileged user that the app will run under.
+# See https://docs.docker.com/go/dockerfile-user-best-practices/
+ARG UID=10001
+RUN adduser \
+  --disabled-password \
+  --gecos "" \
+  --home "/nonexistent" \
+  --shell "/sbin/nologin" \
+  --no-create-home \
+  --uid "${UID}" \
+  appuser
+USER appuser
 
 COPY initial-data /initial-data
 COPY webapp/public/static /static
 
-COPY go.mod /opt/go/go.mod
-COPY go.sum /opt/go/go.sum
-RUN go mod download
+COPY bench/run.sh /run.sh
 
-COPY cmd/ /opt/go/cmd
-COPY bench/ /opt/go/bench
+# Copy the executable from the "build" stage.
+COPY --from=build /bin/benchmarker /bin/
 
-RUN go build -o benchmarker cmd/bench/main.go
-
-ENTRYPOINT ["/opt/go/bench/run.sh"]
+ENTRYPOINT ["/run.sh"]

--- a/bench/Dockerfile
+++ b/bench/Dockerfile
@@ -8,9 +8,6 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
   --mount=type=bind,source=go.mod,target=go.mod \
   go mod download -x
 
-COPY cmd/ /src/cmd
-COPY bench/ /src/bench
-
 RUN --mount=type=cache,target=/go/pkg/mod/ \
   --mount=type=bind,target=. \
   CGO_ENABLED=0 go build -o /bin/benchmarker cmd/bench/main.go

--- a/bench/Dockerfile-payment
+++ b/bench/Dockerfile-payment
@@ -8,9 +8,6 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
   --mount=type=bind,source=go.mod,target=go.mod \
   go mod download -x
 
-COPY cmd/ /src/cmd
-COPY bench/ /src/bench
-
 RUN --mount=type=cache,target=/go/pkg/mod/ \
   --mount=type=bind,target=. \
   CGO_ENABLED=0 go build -o /bin/server cmd/payment/main.go

--- a/bench/Dockerfile-payment
+++ b/bench/Dockerfile-payment
@@ -1,15 +1,46 @@
-FROM golang:1.22
+# syntax=docker/dockerfile:1
 
-RUN mkdir -p /opt/go
-WORKDIR /opt/go
+FROM --platform=$BUILDPLATFORM golang:1.22 AS build
+WORKDIR /src
 
-COPY go.mod /opt/go/go.mod
-COPY go.sum /opt/go/go.sum
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+  --mount=type=bind,source=go.sum,target=go.sum \
+  --mount=type=bind,source=go.mod,target=go.mod \
+  go mod download -x
 
-COPY cmd/ /opt/go/cmd
-COPY bench/ /opt/go/bench
+COPY cmd/ /src/cmd
+COPY bench/ /src/bench
 
-RUN go build -o bin/payment cmd/payment/main.go
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+  --mount=type=bind,target=. \
+  CGO_ENABLED=0 go build -o /bin/server cmd/payment/main.go
 
-CMD [ "/opt/go/bin/payment", "-port", "5556" ]
+FROM alpine:latest AS final
+
+RUN --mount=type=cache,target=/var/cache/apk \
+  apk --update add \
+  ca-certificates \
+  tzdata \
+  && \
+  update-ca-certificates
+
+# Create a non-privileged user that the app will run under.
+# See https://docs.docker.com/go/dockerfile-user-best-practices/
+ARG UID=10001
+RUN adduser \
+  --disabled-password \
+  --gecos "" \
+  --home "/nonexistent" \
+  --shell "/sbin/nologin" \
+  --no-create-home \
+  --uid "${UID}" \
+  appuser
+USER appuser
+
+# Copy the executable from the "build" stage.
+COPY --from=build /bin/server /bin/
+
+EXPOSE 5556
+
+# What the container should run when it is started.
+ENTRYPOINT [ "/bin/server", "-port", "5556" ]

--- a/bench/Dockerfile-shipment
+++ b/bench/Dockerfile-shipment
@@ -8,9 +8,6 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
   --mount=type=bind,source=go.mod,target=go.mod \
   go mod download -x
 
-COPY cmd/ /src/cmd
-COPY bench/ /src/bench
-
 RUN --mount=type=cache,target=/go/pkg/mod/ \
   --mount=type=bind,target=. \
   CGO_ENABLED=0 go build -o /bin/server cmd/shipment/main.go

--- a/bench/Dockerfile-shipment
+++ b/bench/Dockerfile-shipment
@@ -1,17 +1,48 @@
-FROM golang:1.22
+# syntax=docker/dockerfile:1
 
-RUN mkdir -p /opt/go
-WORKDIR /opt/go
+FROM --platform=$BUILDPLATFORM golang:1.22 AS build
+WORKDIR /src
+
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+  --mount=type=bind,source=go.sum,target=go.sum \
+  --mount=type=bind,source=go.mod,target=go.mod \
+  go mod download -x
+
+COPY cmd/ /src/cmd
+COPY bench/ /src/bench
+
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+  --mount=type=bind,target=. \
+  CGO_ENABLED=0 go build -o /bin/server cmd/shipment/main.go
+
+FROM alpine:latest AS final
+
+RUN --mount=type=cache,target=/var/cache/apk \
+  apk --update add \
+  ca-certificates \
+  tzdata \
+  && \
+  update-ca-certificates
+
+# Create a non-privileged user that the app will run under.
+# See https://docs.docker.com/go/dockerfile-user-best-practices/
+ARG UID=10001
+RUN adduser \
+  --disabled-password \
+  --gecos "" \
+  --home "/nonexistent" \
+  --shell "/sbin/nologin" \
+  --no-create-home \
+  --uid "${UID}" \
+  appuser
+USER appuser
 
 COPY initial-data /initial-data
 
-COPY go.mod /opt/go/go.mod
-COPY go.sum /opt/go/go.sum
-RUN go mod download
+# Copy the executable from the "build" stage.
+COPY --from=build /bin/server /bin/
 
-COPY cmd/ /opt/go/cmd
-COPY bench/ /opt/go/bench
+EXPOSE 7002
 
-RUN go build -o bin/shipment cmd/shipment/main.go
-
-CMD [ "/opt/go/bin/shipment", "-data-dir", "/initial-data", "-port", "7002" ]
+# What the container should run when it is started.
+ENTRYPOINT [ "/bin/server", "-data-dir", "/initial-data", "-port", "7002" ]

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 exec "$@"

--- a/compose.yml
+++ b/compose.yml
@@ -4,6 +4,7 @@ services:
     build:
       context: .
       dockerfile: bench/Dockerfile-payment
+      target: final
     ports:
       - "5556:5556"
 
@@ -11,5 +12,6 @@ services:
     build:
       context: .
       dockerfile: bench/Dockerfile-shipment
+      target: final
     ports:
       - "7002:7002"


### PR DESCRIPTION
This pull request includes significant updates to the Dockerfiles for the benchmark services and minor changes to the `compose.yml` and `run.sh` files. The most important changes include restructuring the Dockerfiles to use multi-stage builds, adding non-privileged users, and updating the `compose.yml` to specify build targets.

### Dockerfile Updates:

* [`bench/Dockerfile`](diffhunk://#diff-93465fc7273c359e8aee7c9a379b6d47fde6ba561161dd45b7cc2a6594ee1304L1-R49): Restructured to use multi-stage builds, added non-privileged user, and updated the `ENTRYPOINT` to use `/run.sh`.
* [`bench/Dockerfile-payment`](diffhunk://#diff-9fdead0afe11f5b902967da49b0f3f1bcdc149b1e3b113d728264eac522bce39L1-R46): Restructured to use multi-stage builds, added non-privileged user, and updated the `ENTRYPOINT` to use `/bin/server`.
* [`bench/Dockerfile-shipment`](diffhunk://#diff-e667da3a2697f79610484a124c51b511d213dd235ef3fbff83e749468b94cf60L1-R48): Restructured to use multi-stage builds, added non-privileged user, and updated the `ENTRYPOINT` to use `/bin/server`.

### Minor Changes:

* [`bench/run.sh`](diffhunk://#diff-5aacefcff80dd3542d381e20eba10279067629081946389ec2c7367ce9ea54d5L1-R1): Changed the shebang from `#!/bin/bash` to `#!/bin/sh` for better compatibility.
* [`compose.yml`](diffhunk://#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588R7-R15): Added `target: final` to the `build` sections for `payment` and `shipment` services to specify the final stage of the multi-stage builds.