### PR TITLE
Update Dockerfile for caching layers and change CMD to ENTRYPOINT

### DIFF
--- a/webapp/ruby/Dockerfile
+++ b/webapp/ruby/Dockerfile
@@ -1,20 +1,26 @@
+#syntax=docker/dockerfile:1
+
 FROM ruby:3.3-slim
 
-RUN apt-get update && apt-get install -y \
+RUN \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  apt-get update -qq && apt-get install -y \
   build-essential \
   default-mysql-client \
-  default-libmysqlclient-dev \
-  && rm -rf /var/lib/apt/lists/*
+  default-libmysqlclient-dev
 
 RUN mkdir -p /home/webapp
 
 COPY init.sh /home/init.sh
 
-COPY ruby/Gemfile /home/webapp
-COPY ruby/Gemfile.lock /home/webapp
 WORKDIR /home/webapp
+
+COPY ruby/Gemfile ./
+COPY ruby/Gemfile.lock ./
 RUN bundle config set --local path 'vendor/bundle'
 RUN bundle install
+
 COPY ruby /home/webapp
 
-CMD bundle exec rackup -p 8000 -o 0.0.0.0
+ENTRYPOINT [ "bundle", "exec", "rackup", "-p", "8000", "-o", "0.0.0.0" ]


### PR DESCRIPTION
This pull request includes several updates to the `webapp/ruby/Dockerfile` to improve Docker image build efficiency and ensure consistency in the application startup process.

### Dockerfile Improvements:

* Added Dockerfile syntax version declaration at the top of the file (`#syntax=docker/dockerfile:1`).
* Implemented build cache mounts to speed up `apt-get update` and package installation (`--mount=type=cache,target=/var/lib/apt,sharing=locked` and `--mount=type=cache,target=/var/cache/apt,sharing=locked`).
* Changed the way `Gemfile` and `Gemfile.lock` are copied to the Docker image to ensure they are in the correct directory before running `bundle install`.
* Replaced `CMD` with `ENTRYPOINT` to ensure the application always starts with the specified command (`bundle exec rackup -p 8000 -o 0.0.0.0`).