### PR TITLE
Update base image in Dockerfiles from alpine:latest to alpine:3.20

### DIFF
--- a/bench/Dockerfile
+++ b/bench/Dockerfile
@@ -13,7 +13,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
   CGO_ENABLED=0 go build -o /bin/benchmarker cmd/bench/main.go
 
 
-FROM alpine:latest AS final
+FROM alpine:3.20 AS final
 
 RUN --mount=type=cache,target=/var/cache/apk \
   apk --update add \

--- a/bench/Dockerfile-payment
+++ b/bench/Dockerfile-payment
@@ -12,7 +12,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
   --mount=type=bind,target=. \
   CGO_ENABLED=0 go build -o /bin/server cmd/payment/main.go
 
-FROM alpine:latest AS final
+FROM alpine:3.20 AS final
 
 RUN --mount=type=cache,target=/var/cache/apk \
   apk --update add \

--- a/bench/Dockerfile-shipment
+++ b/bench/Dockerfile-shipment
@@ -12,7 +12,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
   --mount=type=bind,target=. \
   CGO_ENABLED=0 go build -o /bin/server cmd/shipment/main.go
 
-FROM alpine:latest AS final
+FROM alpine:3.20 AS final
 
 RUN --mount=type=cache,target=/var/cache/apk \
   apk --update add \


### PR DESCRIPTION
This pull request includes updates to the `bench` Dockerfiles to ensure compatibility with a specific version of the Alpine Linux base image. The most important changes are as follows:

Updates to Alpine Linux version:

* [`bench/Dockerfile`](diffhunk://#diff-93465fc7273c359e8aee7c9a379b6d47fde6ba561161dd45b7cc2a6594ee1304L16-R16): Changed the base image from `alpine:latest` to `alpine:3.20` to ensure consistent build environments.
* [`bench/Dockerfile-payment`](diffhunk://#diff-9fdead0afe11f5b902967da49b0f3f1bcdc149b1e3b113d728264eac522bce39L15-R15): Updated the base image from `alpine:latest` to `alpine:3.20` to align with the main Dockerfile and maintain consistency.
* [`bench/Dockerfile-shipment`](diffhunk://#diff-e667da3a2697f79610484a124c51b511d213dd235ef3fbff83e749468b94cf60L15-R15): Modified the base image from `alpine:latest` to `alpine:3.20` to match the other Dockerfiles and ensure compatibility.