### PR TITLE
set session.Options.Secure to false for docker

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -363,6 +363,7 @@ func main() {
 
 func getSession(r *http.Request) *sessions.Session {
 	session, _ := store.Get(r, sessionName)
+	session.Options.Secure = false
 
 	return session
 }


### PR DESCRIPTION
This pull request includes a small change to the `postLogin` function in the `webapp/go/main.go` file. The change sets the `Secure` option of the session to `false`.

* [`webapp/go/main.go`](diffhunk://#diff-871eb89e86e63e7eca84f0075cba1a75574a11341cd89d39c7891864d2b085b9R2214): Modified the `postLogin` function to set `session.Options.Secure` to `false`.