### PR TITLE
Remove final stage from Dockerfile for CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ init:
 	$(MAKE) setup-initial-image
 	$(MAKE) setup-bench-image
 	$(MAKE) setup-initial-sql
+	$(MAKE) clean-zip
 
 initial-data/result/initial.sql: initial-data/Dockerfile initial-data/*.tsv initial-data/*.pl
 	cd initial-data && \
@@ -59,5 +60,11 @@ setup-initial-sql:
 	curl -L -O https://github.com/isucon/isucon9-qualify/releases/download/v2/initial.sql.zip && \
 	unzip -qq initial.sql.zip && \
 	mv initial.sql 90_initial.sql
+
+.PHONY: clean-zip
+clean-zip:
+	rm -f initial-data/bench1.zip
+	rm -f webapp/public/initial.zip
+	rm -f webapp/sql/initial.sql.zip
 
 .PHONY: all init vet errcheck staticcheck clean

--- a/Makefile
+++ b/Makefile
@@ -26,12 +26,10 @@ staticcheck:
 clean:
 	rm -rf bin/*
 
-init: webapp/sql/90_initial.sql
+init:
 	$(MAKE) setup-initial-image
 	$(MAKE) setup-bench-image
-
-webapp/sql/90_initial.sql: initial-data/result/initial.sql
-	install -m 0644 initial-data/result/initial.sql webapp/sql/90_initial.sql
+	$(MAKE) setup-initial-sql
 
 initial-data/result/initial.sql: initial-data/Dockerfile initial-data/*.tsv initial-data/*.pl
 	cd initial-data && \
@@ -54,5 +52,12 @@ setup-bench-image:
 	unzip -qq bench1.zip && \
 	rm -rf images && \
 	mv v3_bench1 images
+
+.PHONY: setup-initial-sql
+setup-initial-sql:
+	cd webapp/sql/ && \
+	curl -L -O https://github.com/isucon/isucon9-qualify/releases/download/v2/initial.sql.zip && \
+	unzip -qq initial.sql.zip && \
+	mv initial.sql 90_initial.sql
 
 .PHONY: all init vet errcheck staticcheck clean

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ clean:
 init:
 	$(MAKE) setup-initial-image
 	$(MAKE) setup-bench-image
-	$(MAKE) setup-initial-sql
+	$(MAKE) setup-initial-data
 	$(MAKE) clean-zip
 
 initial-data/result/initial.sql: initial-data/Dockerfile initial-data/*.tsv initial-data/*.pl
@@ -54,17 +54,17 @@ setup-bench-image:
 	rm -rf images && \
 	mv v3_bench1 images
 
-.PHONY: setup-initial-sql
-setup-initial-sql:
-	cd webapp/sql/ && \
-	curl -L -O https://github.com/isucon/isucon9-qualify/releases/download/v2/initial.sql.zip && \
-	unzip -qq initial.sql.zip && \
-	mv initial.sql 90_initial.sql
+.PHONY: setup-initial-data
+setup-initial-data:
+	cd initial-data/result && \
+	curl -L -O https://github.com/isucon/isucon9-qualify/releases/download/v2/initial-data.zip && \
+	unzip -qq initial-data.zip && \
+	mv initial.sql ../../webapp/sql/90_initial.sql
 
 .PHONY: clean-zip
 clean-zip:
 	rm -f initial-data/bench1.zip
 	rm -f webapp/public/initial.zip
-	rm -f webapp/sql/initial.sql.zip
+	rm -f initial-data/result/initial-data.zip
 
 .PHONY: all init vet errcheck staticcheck clean

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,8 @@ webapp/sql/90_initial.sql: initial-data/result/initial.sql
 initial-data/result/initial.sql: initial-data/Dockerfile initial-data/*.tsv initial-data/*.pl
 	cd initial-data && \
 	docker build -t isucon9-qualify/initial-data . && \
-	docker run -v $(shell pwd)/initial-data/result:/opt/initial-data/result -v $(shell pwd)/initial-data/pwcache:/opt/initial-data/pwcache isucon9-qualify/initial-data
+	docker run --rm -v $(shell pwd)/initial-data/result:/opt/initial-data/result -v $(shell pwd)/initial-data/pwcache:/opt/initial-data/pwcache isucon9-qualify/initial-data && \
+	docker rmi isucon9-qualify/initial-data
 
 .PHONY: setup-initial-image
 setup-initial-image:

--- a/bench/Dockerfile
+++ b/bench/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM --platform=$BUILDPLATFORM golang:1.22 AS build
+FROM golang:1.22-bookworm
 WORKDIR /src
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \
@@ -12,18 +12,6 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
   --mount=type=bind,target=. \
   CGO_ENABLED=0 go build -o /bin/benchmarker cmd/bench/main.go
 
-
-FROM alpine:3.20 AS final
-
-RUN --mount=type=cache,target=/var/cache/apk \
-  apk --update add \
-  ca-certificates \
-  tzdata \
-  && \
-  update-ca-certificates
-
-# Create a non-privileged user that the app will run under.
-# See https://docs.docker.com/go/dockerfile-user-best-practices/
 ARG UID=10001
 RUN adduser \
   --disabled-password \
@@ -39,8 +27,5 @@ COPY initial-data /initial-data
 COPY webapp/public/static /static
 
 COPY bench/run.sh /run.sh
-
-# Copy the executable from the "build" stage.
-COPY --from=build /bin/benchmarker /bin/
 
 ENTRYPOINT ["/run.sh"]

--- a/initial-data/.gitignore
+++ b/initial-data/.gitignore
@@ -5,3 +5,4 @@ pwcache/*.txt
 images/
 v3_bench1
 bench1.zip
+result/initial-data.zip

--- a/webapp/sql/.gitignore
+++ b/webapp/sql/.gitignore
@@ -1,1 +1,2 @@
 90_initial.sql
+initial.sql.zip

--- a/webapp/sql/.gitignore
+++ b/webapp/sql/.gitignore
@@ -1,2 +1,1 @@
 90_initial.sql
-initial.sql.zip


### PR DESCRIPTION
This pull request includes several changes to the `bench/Dockerfile` to streamline the Docker build process and remove unnecessary steps. The most important changes include removing the final stage of the Docker build and simplifying the build process.

### Simplification of Docker build process:

* Removed the final stage of the Docker build, which included adding certificates and timezone data, as well as creating a non-privileged user. (`bench/Dockerfile`)
* Removed the step that copied the executable from the "build" stage to the final image. (`bench/Dockerfile`)