### PR TITLE
Refactor Makefile for improved initial data setup and cleanup commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,12 +26,11 @@ staticcheck:
 clean:
 	rm -rf bin/*
 
-init: webapp/sql/90_initial.sql
+init:
 	$(MAKE) setup-initial-image
 	$(MAKE) setup-bench-image
-
-webapp/sql/90_initial.sql: initial-data/result/initial.sql
-	install -m 0644 initial-data/result/initial.sql webapp/sql/90_initial.sql
+	$(MAKE) setup-initial-data
+	$(MAKE) clean-zip
 
 initial-data/result/initial.sql: initial-data/Dockerfile initial-data/*.tsv initial-data/*.pl
 	cd initial-data && \
@@ -53,5 +52,18 @@ setup-bench-image:
 	unzip -qq bench1.zip && \
 	rm -rf images && \
 	mv v3_bench1 images
+
+.PHONY: setup-initial-data
+setup-initial-data:
+	cd initial-data/result && \
+	curl -L -O https://github.com/isucon/isucon9-qualify/releases/download/v2/initial-data.zip && \
+	unzip -qq initial-data.zip && \
+	mv initial.sql ../../webapp/sql/90_initial.sql
+
+.PHONY: clean-zip
+clean-zip:
+	rm -f initial-data/bench1.zip
+	rm -f webapp/public/initial.zip
+	rm -f initial-data/result/initial-data.zip
 
 .PHONY: all init vet errcheck staticcheck clean

--- a/initial-data/.gitignore
+++ b/initial-data/.gitignore
@@ -5,3 +5,4 @@ pwcache/*.txt
 images/
 v3_bench1
 bench1.zip
+result/initial-data.zip


### PR DESCRIPTION
This pull request includes changes to the `Makefile` and `.gitignore` to streamline the setup process and manage initial data more efficiently. The most important changes include updating the initialization process, adding new tasks for handling initial data, and updating the `.gitignore` file.

Improvements to initialization and setup:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L29-R33): Removed the dependency on `webapp/sql/90_initial.sql` and added `setup-initial-data` and `clean-zip` tasks to handle initial data setup and cleanup. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L29-R33) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R56-R68)

Updates to `.gitignore`:

* [`initial-data/.gitignore`](diffhunk://#diff-be8ffb0f8d0b36c2c8adb726cdd49f53647e4763b9e0bf02baa2e54e3cd6d9afR8): Added `result/initial-data.zip` to ignore list to prevent it from being tracked in the repository.