### PR TITLE
Add benchmark output logging and result checking in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,11 @@ jobs:
       - name: Run the benchmark
         continue-on-error: true
         run: |
-          docker container run --add-host host.docker.internal:host-gateway -p 5678:5678 -p 7890:7890 -i isucari-benchmarker /bin/benchmarker -target-url http://host.docker.internal -data-dir /initial-data -static-dir /static -payment-url http://host.docker.internal:5678 -payment-port 5678 -shipment-url http://host.docker.internal:7890 -shipment-port 7890 || echo "BENCHMARK_FAILED=true" >> $GITHUB_ENV
+          docker container run --add-host host.docker.internal:host-gateway -p 5678:5678 -p 7890:7890 -i isucari-benchmarker /bin/benchmarker -target-url http://host.docker.internal -data-dir /initial-data -static-dir /static -payment-url http://host.docker.internal:5678 -payment-port 5678 -shipment-url http://host.docker.internal:7890 -shipment-port 7890 | tee benchmark_output.json || echo "BENCHMARK_FAILED=true" >> $GITHUB_ENV
+
+      - name: Check benchmark result
+        run: |
+          cat benchmark_output.json | jq '.pass' | grep false && echo "BENCHMARK_FAILED=true" >> $GITHUB_ENV || true
 
       - name: Show logs
         run: |


### PR DESCRIPTION
This pull request includes changes to the CI workflow to enhance the handling and checking of benchmark results.

Enhancements to CI workflow:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL94-R98): Modified the benchmark command to output results to `benchmark_output.json` and added a step to check the benchmark result using `jq` to determine if the benchmark passed or failed.