### PR TITLE
Add checks for benchmark_output.json existence and validation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,14 @@ jobs:
 
       - name: Check benchmark result
         run: |
-          cat benchmark_output.json | jq '.pass' | grep false && echo "BENCHMARK_FAILED=true" >> $GITHUB_ENV || true
+          if [ ! -f benchmark_output.json ]; then
+            echo "benchmark_output.json not found"
+            exit 1
+          fi
+          if ! jq -e '.pass == true' benchmark_output.json > /dev/null; then
+            echo "BENCHMARK_FAILED=true" >> $GITHUB_ENV
+            exit 1
+          fi
 
       - name: Show logs
         run: |


### PR DESCRIPTION
This pull request includes an important change to the CI workflow configuration to improve the handling of benchmark results. The update ensures that the benchmark output file exists before checking its contents and properly exits if the benchmark fails.

Changes to CI workflow:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL98-R105): Added a check to ensure `benchmark_output.json` exists and modified the benchmark result check to properly exit if the benchmark fails.