### PR TITLE
Remove toolchain specification from go.mod file

### DIFF
--- a/webapp/go/go.mod
+++ b/webapp/go/go.mod
@@ -2,8 +2,6 @@ module github.com/isucon/isucon9-qualify/webapp/go
 
 go 1.23
 
-toolchain go1.23.0
-
 require (
 	github.com/go-chi/chi/v5 v5.1.0
 	github.com/go-sql-driver/mysql v1.8.1


### PR DESCRIPTION
This pull request includes a small change to the `webapp/go/go.mod` file. The change removes the `toolchain go1.23.0` line to simplify the module configuration.

* [`webapp/go/go.mod`](diffhunk://#diff-318aa8c326576614a6f71c64bcfcb0995df9f21d379aaddcc68cd019d275eadbL5-L6): Removed the `toolchain go1.23.0` line.