### PR TITLE
Add script to update /etc/hosts and modify bundle install command

### DIFF
--- a/provisioning/roles/bootstrap/files/home/isucon/add_hosts.sh
+++ b/provisioning/roles/bootstrap/files/home/isucon/add_hosts.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+  echo "Error: IP address not provided."
+  echo "Usage: $0 <IP_ADDRESS>"
+  exit 1
+fi
+
+ip_address=$1
+
+domains=(
+  "bp.t.isucon.pw"
+  "bs.t.isucon.pw"
+  "payment.t.isucon.pw"
+  "shipment.t.isucon.pw"
+)
+
+{
+  echo ""
+  echo "# The following entries were added automatically by a script."
+  for domain in "${domains[@]}"; do
+    echo "${ip_address} ${domain}"
+  done
+} | sudo tee -a /etc/hosts >/dev/null

--- a/provisioning/roles/bootstrap/tasks/main.yml
+++ b/provisioning/roles/bootstrap/tasks/main.yml
@@ -48,3 +48,11 @@
     owner: isucon
     group: isucon
     mode: 0755
+
+- name: Copy add_hosts.sh
+  copy:
+    src: home/isucon/add_hosts.sh
+    dest: /home/isucon/add_hosts.sh
+    owner: isucon
+    group: isucon
+    mode: 0755

--- a/provisioning/roles/webapp.ruby/tasks/main.yml
+++ b/provisioning/roles/webapp.ruby/tasks/main.yml
@@ -4,7 +4,9 @@
   args:
     chdir: /home/isucon/isucari/webapp/ruby
   shell: |
-    bash -lc "bundle install --path=.bundle"
+    bash -lc "bundle install"
+  environment:
+    PATH: "/home/isucon/local/ruby/bin:{{ ansible_env.PATH }}"
 
 - name: Copy isucari.ruby unit file
   copy:


### PR DESCRIPTION
This pull request includes several changes to the provisioning scripts and tasks to enhance automation and environment setup. The most important changes involve adding a script to automatically update the `/etc/hosts` file and modifying the Ruby web application setup.

Automation enhancements:

* [`provisioning/roles/bootstrap/files/home/isucon/add_hosts.sh`](diffhunk://#diff-32211863f116bbbc31cf4e0e163856389471bd0735d4a884f4bdf61013dfdfd9R1-R24): Added a new script to automatically append IP addresses and domains to the `/etc/hosts` file.
* [`provisioning/roles/bootstrap/tasks/main.yml`](diffhunk://#diff-1b404a10aacc5570779bcd56a2b74a61215a20110e68f67288471129d423df91R51-R58): Added a task to copy the new `add_hosts.sh` script to the target machine.

Environment setup improvements:

* [`provisioning/roles/webapp.ruby/tasks/main.yml`](diffhunk://#diff-01d5e92fc583b2e3304e952d4beb09a1f38256f30c016628fc02df5d3f40afd3L7-R10): Modified the task to install Ruby gems without specifying the installation path and added an environment variable to ensure the correct Ruby binary path is used.