### PR TITLE
fix session options

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -276,7 +276,7 @@ func init() {
 		Options: &sessions.Options{
 			Path:     "/",
 			MaxAge:   86400 * 30,
-			SameSite: http.SameSiteNoneMode,
+			HttpOnly: true,
 		},
 	}
 	cs.MaxAge(cs.Options.MaxAge)


### PR DESCRIPTION
This pull request includes a small but significant change to the `webapp/go/main.go` file. The change enhances the security of session cookies by making them HttpOnly.

* [`webapp/go/main.go`](diffhunk://#diff-871eb89e86e63e7eca84f0075cba1a75574a11341cd89d39c7891864d2b085b9L279-R279): Changed the `SameSite` attribute to `HttpOnly` in the session options to improve security.