### PR TITLE
Update AMI ID and name for isucon9-qualify-app in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@
 
 競技者用・ベンチマーカー (Ubuntu 24.04):
 
-| arch   |        AMI ID         |       AMI name        | 推奨インスタンスタイプ |
-| ------ | :-------------------: | :-------------------: | ---------------------- |
-| x86_64 | ami-037f147dae25cca0b |  isucon9-qualify-app  | c7a.large              |
-| x86_64 | ami-02cd0768ce7639d01 | isucon9-qualify-bench | c7a.xlarge             |
+| arch   |        AMI ID         |           AMI name           | 推奨インスタンスタイプ |
+| ------ | :-------------------: | :--------------------------: | ---------------------- |
+| x86_64 | ami-01e5d6ed3030d5df4 | isucon9-qualify-app-20241013 | c7a.large              |
+| x86_64 | ami-02cd0768ce7639d01 |    isucon9-qualify-bench     | c7a.xlarge             |
 
 ベンチマーカーのIPアドレスが192.0.2.1なら、以下のコマンドを実行して`/etc/hosts`を変更する。
 


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change updates the AMI ID and name for the `isucon9-qualify-app` instance.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L19-R20): Updated the AMI ID and name for the `isucon9-qualify-app` instance to `ami-01e5d6ed3030d5df4` and `isucon9-qualify-app-20241013`, respectively.