### PR TITLE
Add log display step to CI workflow after benchmarks execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,11 @@ jobs:
         run: |
           docker container run --add-host host.docker.internal:host-gateway -p 5678:5678 -p 7890:7890 -i isucari-benchmarker /bin/benchmarker -target-url http://host.docker.internal -data-dir /initial-data -static-dir /static -payment-url http://host.docker.internal:5678 -payment-port 5678 -shipment-url http://host.docker.internal:7890 -shipment-port 7890 | tee benchmark_output.json || echo "BENCHMARK_FAILED=true" >> $GITHUB_ENV
 
+      - name: Show logs
+        run: |
+          cd webapp
+          docker compose logs
+
       - name: Check benchmark result
         run: |
           if [ ! -f benchmark_output.json ]; then
@@ -103,11 +108,6 @@ jobs:
             echo "BENCHMARK_FAILED=true" >> $GITHUB_ENV
             exit 1
           fi
-
-      - name: Show logs
-        run: |
-          cd webapp
-          docker compose logs
 
       - name: Fail if benchmark failed
         if: env.BENCHMARK_FAILED == 'true'


### PR DESCRIPTION
This pull request includes changes to the CI workflow configuration to ensure that logs are shown after the benchmark is run. The most important changes are:

CI Workflow Enhancements:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR96-R100): Added a step to show logs after running the benchmark, ensuring that the logs are available for debugging purposes.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL107-L111): Removed the redundant step to show logs that was previously placed before checking the benchmark result.