### PR TITLE
Update Ruby version to 3.4, add bigdecimal gem in Gemfile and lockfile.

### DIFF
--- a/webapp/ruby/Dockerfile
+++ b/webapp/ruby/Dockerfile
@@ -1,6 +1,6 @@
 #syntax=docker/dockerfile:1
 
-FROM ruby:3.3-slim
+FROM ruby:3.4-slim
 
 RUN \
   --mount=type=cache,target=/var/lib/apt,sharing=locked \

--- a/webapp/ruby/Gemfile
+++ b/webapp/ruby/Gemfile
@@ -4,6 +4,7 @@ gem 'puma'
 gem 'sinatra'
 gem 'mysql2'
 gem 'mysql2-cs-bind'
+gem 'bigdecimal'
 gem 'bcrypt'
 gem 'rackup'
 

--- a/webapp/ruby/Gemfile.lock
+++ b/webapp/ruby/Gemfile.lock
@@ -3,6 +3,7 @@ GEM
   specs:
     base64 (0.2.0)
     bcrypt (3.1.20)
+    bigdecimal (3.1.9)
     logger (1.6.1)
     multi_json (1.15.0)
     mustermann (3.0.3)
@@ -43,6 +44,7 @@ PLATFORMS
 
 DEPENDENCIES
   bcrypt
+  bigdecimal
   mysql2
   mysql2-cs-bind
   puma


### PR DESCRIPTION
This pull request includes updates to the `Dockerfile` and `Gemfile` for the Ruby web application. The most important changes are:

* Updated the Ruby version in the `Dockerfile` from `3.3-slim` to `3.4-slim` to use the latest version.
* Added the `bigdecimal` gem to the `Gemfile` to support high-precision floating-point decimal arithmetic.