### PR TITLE
efactor benchmark run command for better readability in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,20 @@ jobs:
       - name: Run the benchmark
         continue-on-error: true
         run: |
-          docker container run --add-host host.docker.internal:host-gateway -p 5678:5678 -p 7890:7890 -i isucari-benchmarker /bin/benchmarker -target-url http://host.docker.internal -data-dir /initial-data -static-dir /static -payment-url http://host.docker.internal:5678 -payment-port 5678 -shipment-url http://host.docker.internal:7890 -shipment-port 7890 | tee benchmark_output.json || echo "BENCHMARK_FAILED=true" >> $GITHUB_ENV
+          docker container run \
+            --add-host host.docker.internal:host-gateway \
+            -p 5678:5678 \
+            -p 7890:7890 \
+            -i isucari-benchmarker \
+            /bin/benchmarker \
+            -target-url http://host.docker.internal \
+            -data-dir /initial-data \
+            -static-dir /static \
+            -payment-url http://host.docker.internal:5678 \
+            -payment-port 5678 \
+            -shipment-url http://host.docker.internal:7890 \
+            -shipment-port 7890 \
+          | tee benchmark_output.json || echo "BENCHMARK_FAILED=true" >> $GITHUB_ENV
 
       - name: Show logs
         run: |


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/ci.yml` file. The change improves the readability of the `Run the benchmark` step by breaking down the command into multiple lines.

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL94-R107): Reformatted the `docker container run` command to span multiple lines for better readability.