### PR TITLE
Update CI workflow to log benchmark failure message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
             exit 1
           fi
           if ! jq -e '.pass == true' benchmark_output.json > /dev/null; then
-            echo "BENCHMARK_FAILED=true" >> $GITHUB_ENV
+            echo "Benchmark failed: pass is not true"
             exit 1
           fi
 


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/ci.yml` file. The change modifies the output message when a benchmark fails to provide more specific information.

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL123-R123): Changed the benchmark failure message to "Benchmark failed: pass is not true" for better clarity.