### PR TITLE
Update Go version to 1.24.1 in CodeQL workflow configuration.

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.24.1
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL


### PR DESCRIPTION
This pull request includes an update to the `.github/workflows/codeql.yml` file to ensure the use of the latest Go version.

* Updated Go version from `1.22.x` to `1.24.1` in the `jobs:` section of the `.github/workflows/codeql.yml` file.