### PR TITLE
webapp: Use "any" instead of "interface{}" for sqlx.In args

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -655,7 +655,7 @@ func getNewCategoryItems(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var inQuery string
-	var inArgs []interface{}
+	var inArgs []any
 	if itemID > 0 && createdAt > 0 {
 		// paging
 		inQuery, inArgs, err = sqlx.In(


### PR DESCRIPTION
This pull request includes a small change to the `webapp/go/main.go` file. The change updates the type of the `inArgs` variable from `[]interface{}` to `[]any`.