### PR TITLE
Update Makefile dependencies and bump Go version to 1.24.0

### DIFF
--- a/webapp/go/Makefile
+++ b/webapp/go/Makefile
@@ -1,4 +1,4 @@
 all: isucari
 
-isucari: *.go
+isucari: *.go go.mod go.sum
 	go build -o isucari

--- a/webapp/go/go.mod
+++ b/webapp/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/isucon/isucon9-qualify/webapp/go
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/go-chi/chi/v5 v5.2.1


### PR DESCRIPTION
This pull request includes updates to the Go build process and dependencies for the `webapp/go` project. The most important changes ensure the build process is more robust and dependencies are updated to use the latest Go version.

### Build process improvements:
* Updated the `Makefile` to include `go.mod` and `go.sum` as dependencies for the `isucari` target, ensuring the build process accounts for changes in module files. (`webapp/go/Makefile`, [webapp/go/MakefileL3-R3](diffhunk://#diff-78fd90c5e708a99f889e37f5576b333b067dbe215df2b36288f348a4bd46ed21L3-R3))

### Dependency updates:
* Upgraded the Go version in `go.mod` from `1.23.0` to `1.24.0`, aligning the project with the latest features and improvements in the Go language. (`webapp/go/go.mod`, [webapp/go/go.modL3-R3](diffhunk://#diff-318aa8c326576614a6f71c64bcfcb0995df9f21d379aaddcc68cd019d275eadbL3-R3))