### PR TITLE
use os.OpenRoot to serve static files

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -329,6 +329,12 @@ func main() {
 	}
 	defer dbx.Close()
 
+	root, err := os.OpenRoot("../public")
+	if err != nil {
+		log.Fatalf("failed to open root: %v", err)
+	}
+	defer root.Close()
+
 	r := chi.NewRouter()
 
 	// API
@@ -366,7 +372,7 @@ func main() {
 	r.Get("/users/setting", getIndex)
 	// Assets
 	r.Get("/*", func(w http.ResponseWriter, r *http.Request) {
-		http.FileServer(http.Dir("../public")).ServeHTTP(w, r)
+		http.FileServerFS(root.FS()).ServeHTTP(w, r)
 	})
 
 	log.Fatal(http.ListenAndServe(":8000", r))


### PR DESCRIPTION
This pull request updates the `webapp/go/main.go` file to improve the handling of static assets by introducing the use of a root directory object. The changes enhance error handling and simplify the file server setup.

### Improvements to static asset handling:

* Introduced a `root` object using `os.OpenRoot("../public")` to manage the root directory for static assets, with proper error handling and cleanup using `defer`.
* Updated the file server setup to use `http.FileServerFS(root.FS())` instead of directly serving the directory with `http.FileServer(http.Dir("../public"))`, leveraging the new `root` object.