### PR TITLE
Update PHP to 8.4.2, fetch latest Composer, and enable PHP webapp role

### DIFF
--- a/provisioning/roles/php/tasks/main.yml
+++ b/provisioning/roles/php/tasks/main.yml
@@ -16,17 +16,16 @@
 - name: Install PHP
   become: yes
   become_user: isucon
-  when: php_version_output is failed or php_version_output.stdout != "7.2.21"
+  when: php_version_output is failed or php_version_output.stdout != "8.4.2"
   args:
     chdir: /home/isucon
   command: >
-    /home/isucon/xbuild/php-install 7.2.21 /home/isucon/local/php --
-    --with-pcre-regex --with-zlib --enable-fpm --enable-pdo --with-pear
-    --with-mysqli=mysqlnd --with-pdo-mysql=mysqlnd --with-openssl
-    --with-pcre-regex --with-pcre-dir --with-libxml-dir --enable-opcache
-    --enable-bcmath --with-bz2 --enable-calendar --enable-cli --enable-shmop
-    --enable-sysvsem --enable-sysvshm --enable-sysvmsg --enable-mbregex
-    --enable-mbstring --enable-pcntl --enable-sockets --with-curl --enable-zip
+    /home/isucon/xbuild/php-install 8.4.2 /home/isucon/local/php --
+    --enable-fpm --enable-pdo --with-pear --with-mysqli=mysqlnd 
+    --with-pdo-mysql=mysqlnd --with-openssl --enable-opcache --enable-bcmath 
+    --with-bz2 --enable-calendar --enable-cli --enable-shmop --enable-sysvsem 
+    --enable-sysvshm --enable-sysvmsg --enable-mbstring --enable-pcntl 
+    --enable-sockets --with-curl --enable-zip --with-zlib
   environment:
     PHP_BUILD_EXTRA_MAKE_ARGUMENTS: "-j {{ nproc | default('1') }}"
 
@@ -77,8 +76,7 @@
   become: yes
   become_user: isucon
   get_url:
-    url: https://getcomposer.org/download/1.9.0/composer.phar
+    url: https://getcomposer.org/download/latest-stable/composer.phar
     dest: /home/isucon/local/php/bin/composer
-    sha256sum: c9dff69d092bdec14dee64df6677e7430163509798895fbd54891c166c5c0875
     mode: 0755
   when: composer_version_output is failed

--- a/provisioning/webapp.yml
+++ b/provisioning/webapp.yml
@@ -10,14 +10,14 @@
     - mysql
     - golang
     # - perl
-    # - php
+    - php
     - ruby
     # - python
     # - nodejs
     - webapp.mysql
     - webapp.golang
     # - webapp.perl
-    # - webapp.php
+    - webapp.php
     - webapp.ruby
     # - webapp.python
     # - webapp.nodejs
@@ -37,3 +37,4 @@
         - nginx.service
         - mysql.service
         - isucari.golang.service
+        - isucari.php.service


### PR DESCRIPTION
This pull request updates the provisioning scripts to enable PHP 8.4.2, modernize Composer installation, and include PHP-related services in the web application setup. Below is a summary of the most important changes:

### PHP Version Upgrade:
* Updated the PHP version from `7.2.21` to `8.4.2` in the `provisioning/roles/php/tasks/main.yml` file. This includes modifying the installation command to match the new version and adjusting the configuration flags accordingly. (`[provisioning/roles/php/tasks/main.ymlL19-R28](diffhunk://#diff-9dbdd5fde6b2e3b159142c1f4da1239894810196a9db07445c9d02ff5a368f6fL19-R28)`)

### Composer Modernization:
* Changed the Composer download URL to always fetch the latest stable version instead of a specific version (`1.9.0`). Removed the hardcoded SHA256 checksum as it is no longer applicable. (`[provisioning/roles/php/tasks/main.ymlL80-L82](diffhunk://#diff-9dbdd5fde6b2e3b159142c1f4da1239894810196a9db07445c9d02ff5a368f6fL80-L82)`)

### PHP Service and Webapp Integration:
* Enabled PHP and its associated web application service (`isucari.php.service`) in the `provisioning/webapp.yml` file. Previously commented-out entries for PHP and `webapp.php` were uncommented, and the PHP service was added to the list of required services. (`[[1]](diffhunk://#diff-f85b7e9b54fa49cf44440d2b8a2de4acb9af7544b2807a38b520d6b816d90c63L13-R20)`, `[[2]](diffhunk://#diff-f85b7e9b54fa49cf44440d2b8a2de4acb9af7544b2807a38b520d6b816d90c63R40)`)