### PR TITLE
update Python version to 3.13.1

### DIFF
--- a/provisioning/roles/python/tasks/main.yml
+++ b/provisioning/roles/python/tasks/main.yml
@@ -13,14 +13,14 @@
   debug:
     var: python_version_output
 
-- name: Install Python 3.7.4
+- name: Install Python
   become: yes
   become_user: isucon
-  when: python_version_output is failed or python_version_output.stdout != "Python 3.7.4"
+  when: python_version_output is failed or python_version_output.stdout != "Python 3.13.1"
   args:
     chdir: /home/isucon
   command: |
-    /home/isucon/xbuild/python-install 3.7.4 /home/isucon/local/python
+    /home/isucon/xbuild/python-install 3.13.1 /home/isucon/local/python
 
 - name: Add PATH for Python
   become: yes

--- a/renovate.json
+++ b/renovate.json
@@ -36,6 +36,28 @@
       "matchStrings": [
         "go(?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
       ]
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/provisioning/roles/python/tasks/main.yml/"
+      ],
+      "datasourceTemplate": "python-version",
+      "depNameTemplate": "python",
+      "matchStrings": [
+        "python-install (?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
+      ]
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/provisioning/roles/python/tasks/main.yml/"
+      ],
+      "datasourceTemplate": "python-version",
+      "depNameTemplate": "python",
+      "matchStrings": [
+        "python_version_output.stdout != \"Python (?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
+      ]
     }
   ],
   "packageRules": [


### PR DESCRIPTION
This pull request includes updates to Python version management in the provisioning process and enhancements to the Renovate configuration to automate dependency updates for Python versions. The key changes focus on upgrading the Python version and ensuring Renovate can track and update it automatically.

### Python version upgrade:
* Updated the Python version installed in the provisioning script from `3.7.4` to `3.13.1` in `provisioning/roles/python/tasks/main.yml`. This includes updating the version check and the installation command.

### Renovate configuration enhancements:
* Added new `customType` rules in `renovate.json` to detect and manage Python version updates in `provisioning/roles/python/tasks/main.yml`. These rules use regex patterns to match Python versions in the installation command and version check.