### PR TITLE
Add PHP version regex rules for renovate updates in provisioning role

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -58,6 +58,30 @@
       "matchStrings": [
         "python_version_output.stdout != \"Python (?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
       ]
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/provisioning/roles/php/tasks/main.yml/"
+      ],
+      "datasourceTemplate": "php-version",
+      "depNameTemplate": "php",
+      "extractVersionTemplate": "^php-(?<version>.*)$",
+      "matchStrings": [
+        "php-install (?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)"
+      ]
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/provisioning/roles/php/tasks/main.yml/"
+      ],
+      "datasourceTemplate": "php-version",
+      "depNameTemplate": "php",
+      "extractVersionTemplate": "^php-(?<version>.*)$",
+      "matchStrings": [
+        "php_version_output\\.stdout != \"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
+      ]
     }
   ],
   "packageRules": [


### PR DESCRIPTION
This pull request updates the `renovate.json` configuration file to add new custom rules for managing PHP dependencies. The changes introduce additional regex-based configurations to handle version extraction and dependency management for PHP-related files.

### Updates to dependency management:

* Added a new `customType: regex` configuration for files matching the pattern `/provisioning/roles/php/tasks/main.yml/`. This configuration uses `github-tags` as the datasource, targets the `php/php-src` dependency, and extracts versions using the regex pattern `^php-(?<version>.*). It matches strings in the format `php-install (?<currentValue>[0-9]+\.[0-9]+\.[0-9]+)`.

* Added another `customType: regex` configuration for the same file pattern (`/provisioning/roles/php/tasks/main.yml/`). This configuration also uses `github-tags` as the datasource and targets `php/php-src`. It extracts versions using the same regex pattern `^php-(?<version>.*) but matches strings in the format `php_version_output\.stdout != "(?<currentValue>[0-9]+\.[0-9]+\.[0-9]+)"`.