### PR TITLE
fix renovate php datasource

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -64,9 +64,9 @@
       "managerFilePatterns": [
         "/provisioning/roles/php/tasks/main.yml/"
       ],
-      "datasourceTemplate": "php-version",
-      "depNameTemplate": "php",
-      "extractVersionTemplate": "^php-(?<version>.*)$",
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "php/php-src",
+      "extractVersionTemplate": "^php-(?<version>[0-9]+\\.[0-9]+\\.[0-9]+)$",
       "matchStrings": [
         "php-install (?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)"
       ]
@@ -76,9 +76,9 @@
       "managerFilePatterns": [
         "/provisioning/roles/php/tasks/main.yml/"
       ],
-      "datasourceTemplate": "php-version",
-      "depNameTemplate": "php",
-      "extractVersionTemplate": "^php-(?<version>.*)$",
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "php/php-src",
+      "extractVersionTemplate": "^php-(?<version>[0-9]+\\.[0-9]+\\.[0-9]+)$",
       "matchStrings": [
         "php_version_output\\.stdout != \"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
       ]


### PR DESCRIPTION
This pull request updates the Renovate configuration to improve the accuracy of version extraction for PHP dependencies. The changes involve switching the data source and updating the dependency name and version extraction template.

### Renovate configuration updates:

* Updated the `datasourceTemplate` from `php-version` to `github-tags` to use a more reliable data source for PHP versions. [[1]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L67-R69) [[2]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L79-R81)
* Changed the `depNameTemplate` from `php` to `php/php-src` to align with the new data source structure. [[1]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L67-R69) [[2]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L79-R81)
* Refined the `extractVersionTemplate` to match semantic versioning (e.g., `x.y.z`) for improved version parsing accuracy. [[1]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L67-R69) [[2]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L79-R81)