### PR TITLE
Uncomment python and webapp.python in provisioning/webapp.yml

### DIFF
--- a/provisioning/webapp.yml
+++ b/provisioning/webapp.yml
@@ -12,14 +12,14 @@
     # - perl
     - php
     - ruby
-    # - python
+    - python
     # - nodejs
     - webapp.mysql
     - webapp.golang
     # - webapp.perl
     - webapp.php
     - webapp.ruby
-    # - webapp.python
+    - webapp.python
     # - webapp.nodejs
     - nginx.certs
     - webapp.nginx


### PR DESCRIPTION
This pull request updates the `provisioning/webapp.yml` file to enable support for Python and WebApp Python by uncommenting their respective entries.

Key change:

* [`provisioning/webapp.yml`](diffhunk://#diff-f85b7e9b54fa49cf44440d2b8a2de4acb9af7544b2807a38b520d6b816d90c63L15-R22): Uncommented the `python` and `webapp.python` entries to include them in the provisioning configuration.