### PR TITLE
Remove isucari.php.service from webapp provisioning configuration

### DIFF
--- a/provisioning/webapp.yml
+++ b/provisioning/webapp.yml
@@ -37,4 +37,3 @@
         - nginx.service
         - mysql.service
         - isucari.golang.service
-        - isucari.php.service


### PR DESCRIPTION
This pull request removes the `isucari.php.service` entry from the `provisioning/webapp.yml` file. This change likely reflects a deprecation or removal of the PHP-based service from the provisioning configuration.