### PR TITLE
add ansible settings for node.js

### DIFF
--- a/provisioning/roles/nodejs/tasks/main.yml
+++ b/provisioning/roles/nodejs/tasks/main.yml
@@ -13,14 +13,14 @@
   debug:
     var: nodejs_version_output
 
-- name: Install Node.js 12.9.1
+- name: Install Node.js
   become: yes
   become_user: isucon
-  when: nodejs_version_output is failed or nodejs_version_output.stdout != "v12.9.1"
+  when: nodejs_version_output is failed or nodejs_version_output.stdout != "v22.18.0"
   args:
     chdir: /home/isucon
   command: |
-    /home/isucon/xbuild/node-install v12.9.1 /home/isucon/local/node
+    /home/isucon/xbuild/node-install v22.18.0 /home/isucon/local/node
 
 - name: Add PATH for Node.js
   become: yes
@@ -37,4 +37,4 @@
   args:
     chdir: /home/isucon
   shell: |
-    bash -lc "/home/isucon/local/node/bin/npm install -g npm@6.11.2"
+    bash -lc "/home/isucon/local/node/bin/npm install -g npm@latest"

--- a/provisioning/roles/webapp.nodejs/files/etc/systemd/system/isucari.nodejs.service
+++ b/provisioning/roles/webapp.nodejs/files/etc/systemd/system/isucari.nodejs.service
@@ -5,7 +5,7 @@ Description = isucon9 qualifier main application in nodejs
 WorkingDirectory=/home/isucon/isucari/webapp/nodejs
 EnvironmentFile=/home/isucon/env.sh
 
-ExecStart = /home/isucon/local/node/bin/node /home/isucon/isucari/webapp/nodejs/node_modules/.bin/ts-node index.ts
+ExecStart = /home/isucon/local/node/bin/node /home/isucon/isucari/webapp/nodejs/dist/index.js
 
 Restart   = always
 Type      = simple

--- a/provisioning/roles/webapp.nodejs/tasks/main.yml
+++ b/provisioning/roles/webapp.nodejs/tasks/main.yml
@@ -1,10 +1,18 @@
-- name: Install isucari.nodejs
+- name: Install isucari.nodejs dependencies
   become: yes
   become_user: isucon
   args:
     chdir: /home/isucon/isucari/webapp/nodejs
   shell: |
     bash -lc "/home/isucon/local/node/bin/npm install"
+
+- name: Build isucari.nodejs
+  become: yes
+  become_user: isucon
+  args:
+    chdir: /home/isucon/isucari/webapp/nodejs
+  shell: |
+    bash -lc "/home/isucon/local/node/bin/npm run build"
 
 - name: Copy isucari.nodejs unit file
   copy:

--- a/provisioning/webapp.yml
+++ b/provisioning/webapp.yml
@@ -13,14 +13,14 @@
     - php
     - ruby
     - python
-    # - nodejs
+    - nodejs
     - webapp.mysql
     - webapp.golang
     # - webapp.perl
     - webapp.php
     - webapp.ruby
     - webapp.python
-    # - webapp.nodejs
+    - webapp.nodejs
     - nginx.certs
     - webapp.nginx
 

--- a/renovate.json
+++ b/renovate.json
@@ -82,6 +82,28 @@
       "matchStrings": [
         "php_version_output\\.stdout != \"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
       ]
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/provisioning/roles/nodejs/tasks/main.yml/"
+      ],
+      "datasourceTemplate": "node-version",
+      "depNameTemplate": "node",
+      "matchStrings": [
+        "node-install v(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)"
+      ]
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/provisioning/roles/nodejs/tasks/main.yml/"
+      ],
+      "datasourceTemplate": "node-version",
+      "depNameTemplate": "node",
+      "matchStrings": [
+        "nodejs_version_output\\.stdout != \"v(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
+      ]
     }
   ],
   "packageRules": [


### PR DESCRIPTION
This pull request updates the provisioning and deployment process for the Node.js web application, modernizing the Node.js and npm versions, ensuring the app is built before deployment, and enabling the Node.js stack in the main provisioning pipeline. The most important changes are grouped below.

**Node.js and npm version upgrades:**

* Updated Node.js installation in `main.yml` to use version `v22.18.0` instead of `v12.9.1`, and changed the npm installation to always use the latest version instead of a fixed version. [[1]](diffhunk://#diff-3afbfe67008f509195aa7fcdde7c6337a12f3ba2a3eddf00e4c9c0be39d9bb4dL16-R23) [[2]](diffhunk://#diff-3afbfe67008f509195aa7fcdde7c6337a12f3ba2a3eddf00e4c9c0be39d9bb4dL40-R40)
* Added Renovate configuration to automatically detect and manage Node.js version updates in the provisioning scripts.

**Web application build and deployment improvements:**

* Modified the systemd service to run the built JavaScript file (`dist/index.js`) instead of using `ts-node` to run TypeScript directly, ensuring production deployment uses compiled code.
* Split the installation and build steps for the Node.js web application in the provisioning tasks, explicitly running `npm run build` after installing dependencies.

**Provisioning pipeline changes:**

* Enabled the Node.js stack and its web application provisioning by uncommenting the relevant roles in `webapp.yml`, ensuring Node.js is now part of the standard deployment process.