### PR TITLE
Use crypto.randomInt instead of randomBytes for secureRandomStr

### DIFF
--- a/webapp/nodejs/src/utils.ts
+++ b/webapp/nodejs/src/utils.ts
@@ -1,14 +1,13 @@
-import { randomBytes } from 'crypto';
+import { randomInt } from 'crypto';
 import bcrypt from 'bcrypt';
 import { BCRYPT_COST } from './constants.js';
 
 export function secureRandomStr(length: number): string {
   const k = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz-';
-  const bytes = randomBytes(length);
   let result = '';
 
   for (let i = 0; i < length; i++) {
-    result += k[bytes[i]! % k.length];
+    result += k[randomInt(k.length)];
   }
 
   return result;


### PR DESCRIPTION
This pull request updates the random string generation logic in the `secureRandomStr` function to use `randomInt` from the `crypto` module instead of `randomBytes`. This change simplifies the code and ensures each character is chosen independently and securely.

Random string generation update:

* [`webapp/nodejs/src/utils.ts`](diffhunk://#diff-c89483bd51bd4c314775d02515f51578915de4d47dd290fd163c3b8d9cda8bb3L1-R10): Replaced the use of `randomBytes` with `randomInt` for generating random characters in the `secureRandomStr` function, simplifying the implementation and maintaining cryptographic security.